### PR TITLE
added initial draft spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ default_attributes:
     mandatory: true
   alias:
     mandatory: true
-x-custom_attributes:
+custom_attributes:
 - name: some_custom_name
   mandatory: true
 - name: some_other_custom_attribute

--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ default_attributes:
     mandatory: true
   alias:
     mandatory: true
-custom_attributes:
+x-custom_attributes:
 - name: some_custom_name
   mandatory: true
 - name: some_other_custom_attribute
   mandatory: false
+- name: some_super_custom_attribute
+  mandatory: true
+  x-custom_property: true
+  x-an_other_custom_p: "Contents of this custom property" 
 ```
 ## Usage
 Intended to use as command wrapper for the `wg show` and `wg set` commands from [wireguard-tools](https://manpages.debian.org/unstable/wireguard-tools/wg.8.en.html).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # wg-meta
-An apporach to add metadata to the main wireguard config, written in Perl
+An approach to add metadata to the main wireguard config, written in Perl.
 
 ## Configuration
-There is only one config file: `wg-meta.contract` which defines the additional (meta-) attributes:
-```text
-# ATTRIBUTE,    IS_OPTIONAL
-name,           0,
-created,        0,
-description,    1,
-alias,          1,
-# And btw, comments are supported :)
+There is only one config file: `wg-meta.yaml` which defines the additional (meta-) attributes.:
+```yaml
+# according to wg-meta.schema.json
+attributes:
+  - name: name
+    mandatory: true
+  - name: created
+    mandatory: false
+  - name: description
+    mandatory: false
+  - name: alias
+    mandatory: false
 ```
 ## Usage
 Intended to use as command wrapper for the `wg show` and `wg set` commands from [wireguard-tools](https://manpages.debian.org/unstable/wireguard-tools/wg.8.en.html).
@@ -27,7 +31,7 @@ wg-meta set wg0 alias some_alias description "Some Desc"
 wg-meta set wg0 [alias|peer] +qz742hzxD3E5z5QF7VOvleVS1onavQpXBK3NdTh40g= allowed-ips 0.0.0.0/0
 ```
 ## Under the hood
-The main advantage is that this tool is not dependent on any other storage, meta data is stored inside the corresponding
+The main advantage is that this tool is not dependent on any other storage, metadata is stored inside the corresponding
 `wgXX.conf` file (Comments prefixed with `#-`):
 ```text
 [Interface]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # wg-meta
-An apporach to add metadata to the main wireguard config
+An apporach to add metadata to the main wireguard config, written in Perl
+
+## Configuration
+There is only one config file: `wg-meta.contract` which defines the additional (meta-) attributes:
+```text
+# ATTRIBUTE,    IS_OPTIONAL
+name,           0,
+created,        0,
+description,    1,
+alias,          1,
+# And btw, comments are supported :)
+```
+## Usage
+Intended to use as command wrapper for the `wg show` and `wg set` commands from [wireguard-tools](https://manpages.debian.org/unstable/wireguard-tools/wg.8.en.html).
+```bash
+wg-meta show
+# Some fancy output (tbd.)
+
+# Access using peer
+wg-meta set wg0 peer +qz742hzxD3E5z5QF7VOvleVS1onavQpXBK3NdTh40g= name Fancy_meta_name
+
+# Access using alias
+wg-meta set wg0 alias some_alias description "Some Desc"
+
+# Some "default" operation -> forwarded to the original wg command
+wg-meta set wg0 [alias|peer] +qz742hzxD3E5z5QF7VOvleVS1onavQpXBK3NdTh40g= allowed-ips 0.0.0.0/0
+```
+## Under the hood
+The main advantage is that this tool is not dependent on any other storage, meta data is stored inside the corresponding
+`wgXX.conf` file (Comments prefixed with `#-`):
+```text
+[Interface]
+#-Alias = some_alias
+#-Description = Some Desc
+Address = 10.0.0.7/24
+ListenPort = 6666
+PrivateKey = WEkEJW3b4TDmRvN+G+K9elzq52/djAXT+LAB6BSEUmM=
+
+[Peer]
+#-Name = Fancy_meta_name
+PublicKey = +qz742hzxD3E5z5QF7VOvleVS1onavQpXBK3NdTh40g=
+AllowedIPs = 0.0.0.0/0
+Endpoint = wg.example.com
+```
+

--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ An approach to add metadata to the main wireguard config, written in Perl.
 There is only one config file: `wg-meta.yaml` which defines the additional (meta-) attributes.:
 ```yaml
 # according to wg-meta.schema.json
-attributes:
-  - name: name
+default_attributes:
+  name:
     mandatory: true
-  - name: created
-    mandatory: false
-  - name: description
-    mandatory: false
-  - name: alias
-    mandatory: false
+  alias:
+    mandatory: true
+custom_attributes:
+- name: some_custom_name
+  mandatory: true
+- name: some_other_custom_attribute
+  mandatory: false
 ```
 ## Usage
 Intended to use as command wrapper for the `wg show` and `wg set` commands from [wireguard-tools](https://manpages.debian.org/unstable/wireguard-tools/wg.8.en.html).

--- a/wg-meta.contract
+++ b/wg-meta.contract
@@ -1,0 +1,6 @@
+# ATTRIBUTE,    IS_OPTIONAL
+name,           0,
+created,        0,
+description,    1,
+alias,          1,
+# And btw, comments are supported :)

--- a/wg-meta.contract
+++ b/wg-meta.contract
@@ -1,6 +1,0 @@
-# ATTRIBUTE,    IS_OPTIONAL
-name,           0,
-created,        0,
-description,    1,
-alias,          1,
-# And btw, comments are supported :)

--- a/wg-meta.schema.json
+++ b/wg-meta.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/sirtoobii/wg-meta/wg-meta.schema.json",
+  "definitions": {
+    "attribute": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mandatory": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "mandatory"
+      ]
+    }
+  },
+  "title": "wg-meta configuration",
+  "type": "object",
+  "properties": {
+    "attributes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/attribute"
+      }
+    }
+  }
+}

--- a/wg-meta.schema.json
+++ b/wg-meta.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://github.com/sirtoobii/wg-meta/wg-meta.schema.json",
   "definitions": {
     "custom_attribute": {
+      "additionalProperties": true,
       "type": "object",
       "properties": {
         "name": {
@@ -18,6 +19,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "title": "wg-meta configuration",
   "type": "object",
   "properties": {
@@ -33,7 +35,7 @@
         }
       }
     },
-    "custom_attributes": {
+    "x-custom_attributes": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/custom_attribute"

--- a/wg-meta.schema.json
+++ b/wg-meta.schema.json
@@ -3,7 +3,6 @@
   "$id": "https://github.com/sirtoobii/wg-meta/wg-meta.schema.json",
   "definitions": {
     "custom_attribute": {
-      "additionalProperties": true,
       "type": "object",
       "properties": {
         "name": {
@@ -13,6 +12,11 @@
           "type": "boolean"
         }
       },
+      "patternProperties": {
+        "^x-": {
+        }
+      },
+      "additionalProperties": false,
       "required": [
         "name",
         "mandatory"
@@ -35,7 +39,7 @@
         }
       }
     },
-    "x-custom_attributes": {
+    "custom_attributes": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/custom_attribute"

--- a/wg-meta.schema.json
+++ b/wg-meta.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/sirtoobii/wg-meta/wg-meta.schema.json",
   "definitions": {
-    "attribute": {
+    "custom_attribute": {
       "type": "object",
       "properties": {
         "name": {
@@ -21,10 +21,22 @@
   "title": "wg-meta configuration",
   "type": "object",
   "properties": {
-    "attributes": {
+    "default_attributes": {
+      "name": {
+        "mandatory": {
+          "type": "boolean"
+        }
+      },
+      "alias": {
+        "mandatory": {
+          "type": "boolean"
+        }
+      }
+    },
+    "custom_attributes": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/attribute"
+        "$ref": "#/definitions/custom_attribute"
       }
     }
   }

--- a/wg-meta.yaml
+++ b/wg-meta.yaml
@@ -1,0 +1,10 @@
+---according to wg-meta.schema.json
+attributes:
+  - name: name
+    mandatory: true
+  - name: created
+    mandatory: false
+  - name: description
+    mandatory: false
+  - name: alias
+    mandatory: false


### PR DESCRIPTION
Since all* existing wireguard-gui projects[1,2,3,4] relay on some sort of external storage for the meta data, I propose `wg-meta` - a tool for storing peer related metadata directly in the respective `wgXX.conf` files.

## Things to discuss:
### The whole wrapper-approach, needed?
- (+) Easier to use: users can use `wg-meta` as a "drop-in" replacement.
- (-) More complex to develop -> depends on the "contract" idea.

###  The idea of the _contract_-file which specifies the allowed attributes
- (+) Would make the wrapper approach easier -> forward all attributes not defined to the main `wg` command.
- (+) Would allow us to print the same amount of (additional) rows per peer/interface.
- (+) Easier integration of external tools such as monitoring tools.
- (-) Not flexible, each peer must have the same set of attributes-names.

### Alias feature (internal translation to peer-publickey/interface-privatekey)
- (+) Would improve the usability quite a bit.
- (-) Again, unnecessary complex addition?

### Other
- Storage format in the `wgXX.conf` files.
- Format of `wg-meta.conf` file

[1]-[https://github.com/Place1/wg-access-server](https://github.com/Place1/wg-access-server)
[2]-[https://github.com/vx3r/wg-gen-web](https://github.com/vx3r/wg-gen-web)
[3]-[https://github.com/EmbarkStudios/wg-ui](https://github.com/EmbarkStudios/wg-ui)
[4]-[https://github.com/subspacecommunity/subspace](https://github.com/subspacecommunity/subspace)

*Probably there are more, however, these four seem to be the most promising ones.